### PR TITLE
Add support for authorize flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@types/node": "^20",
-        "@uphold/enterprise-widget-messaging-types": "^0.4.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.5.0",
         "@vitest/coverage-v8": "^3.0.7",
         "@vitest/eslint-plugin": "^1.1.36",
         "eslint": "^9.21.0",
@@ -3059,9 +3059,9 @@
       "link": true
     },
     "node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.4.0.tgz",
-      "integrity": "sha512-dAdpuk7NHIXQvbLjZBSN9J9goE/a2QwzNSe6g7azTtYM8QW6DZr28XMjkqk5rMCOWnouODXHB0C8V5qhtIa8oA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.5.0.tgz",
+      "integrity": "sha512-BVIoc9PhI+V+z0El2ekDm4b/C9AklU0XTNk3X+4xCF+Tw4REagCDuyAGK7EeAkPMDEhNo+tNqPS9Mslw8lpkyQ=="
     },
     "node_modules/@uphold/widget-test-app": {
       "resolved": "projects/widget-test-app",
@@ -12005,7 +12005,7 @@
       "name": "@uphold/enterprise-payment-widget-web-sdk",
       "version": "0.4.1",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.4.0"
+        "@uphold/enterprise-widget-messaging-types": "^0.5.0"
       }
     },
     "packages/widget-messaging-types": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@types/node": "^20",
-    "@uphold/enterprise-widget-messaging-types": "^0.4.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.5.0",
     "@vitest/coverage-v8": "^3.0.7",
     "@vitest/eslint-plugin": "^1.1.36",
     "eslint": "^9.21.0",

--- a/packages/payment-widget-web-sdk/README.md
+++ b/packages/payment-widget-web-sdk/README.md
@@ -33,22 +33,24 @@ import {
 const paymentSession = {};
 
 // Initialize the widget with the payment session.
-const widget = new PaymentWidget(paymentSession);
+// Accepts an optional type parameter `TFlow` which narrows
+// the type of the `complete` event.
+const widget = new PaymentWidget<'select-for-deposit'>(paymentSession);
 
 // Register event handlers.
 widget.on('complete', (e: PaymentWidgetCompleteEvent) => {
   // 'complete' event is raised when the user completes the flow.
-  console.log(`'complete' event raised. Account id: `, e.detail.externalAccountId);
+  console.log(`'complete' event raised. Account id: `, e.detail.selection.id);
   widget.unmount();
 });
 
-widget.on('cancel', (_: WidgetCancelEvent) => {
+widget.on('cancel', (_: PaymentWidgetCancelEvent) => {
   // 'cancel' event is raised when the user cancels the flow.
   console.log(`'cancel' event raised`);
   widget.unmount();
 });
 
-widget.on('error', (e: WidgetErrorEvent) => {
+widget.on('error', (e: PaymentWidgetErrorEvent) => {
   // 'error' event is raised when the widget encounters an unrecoverable error.
   console.log(`'error' event raised. error: `, e.detail.error);
   widget.unmount();

--- a/packages/payment-widget-web-sdk/package.json
+++ b/packages/payment-widget-web-sdk/package.json
@@ -29,6 +29,6 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.4.0"
+    "@uphold/enterprise-widget-messaging-types": "^0.5.0"
   }
 }

--- a/packages/payment-widget-web-sdk/src/payment-widget.ts
+++ b/packages/payment-widget-web-sdk/src/payment-widget.ts
@@ -5,8 +5,12 @@
  * Module dependencies.
  */
 
-import type { EventByType, PaymentWidgetEvent, WidgetMountIframeOptions, WidgetOptions } from './types';
-import type { PaymentWidgetSession } from '@uphold/enterprise-widget-messaging-types';
+import type { PaymentWidgetEvent, WidgetMountIframeOptions, WidgetOptions } from './types';
+import type {
+  PaymentWidgetFlow,
+  PaymentWidgetMessageEvent,
+  PaymentWidgetSession
+} from '@uphold/enterprise-widget-messaging-types';
 import { Widget } from './widget';
 import { logSymbol } from './constants';
 
@@ -33,11 +37,16 @@ import { logSymbol } from './constants';
  *
  *   paymentWidget.unmount();
  * });
- *
+ * @template TFlow - (optional) The type of the payment widget flow. This determines the specific
+ * flow-related events and data that the widget will handle.
  * @public
  * ```
  */
-class PaymentWidget extends Widget<PaymentWidgetSession, PaymentWidgetEvent> {
+class PaymentWidget<TFlow extends PaymentWidgetFlow = PaymentWidgetFlow> extends Widget<
+  PaymentWidgetSession,
+  PaymentWidgetMessageEvent,
+  PaymentWidgetEvent<TFlow>
+> {
   /**
    * Creates a new instance of a Payment Widget.
    *
@@ -101,9 +110,9 @@ class PaymentWidget extends Widget<PaymentWidgetSession, PaymentWidgetEvent> {
    * @param listener The callback function to execute when the event is triggered.
    * The callback receives the event object as a parameter, which contains additional details about the event.
    */
-  override on<T extends PaymentWidgetEvent['type']>(
+  override on<T extends PaymentWidgetEvent['detail']['type']>(
     event: T,
-    listener: (event: EventByType<PaymentWidgetEvent, T>) => void
+    listener: (event: Extract<PaymentWidgetEvent<TFlow>, { detail: { type: T } }>) => void
   ) {
     super.on(event, listener);
   }
@@ -132,7 +141,10 @@ class PaymentWidget extends Widget<PaymentWidgetSession, PaymentWidgetEvent> {
    *
    * @throws {Error} If the `listener` parameter is not a function.
    */
-  override off(event: PaymentWidgetEvent['type'], listener: (event: PaymentWidgetEvent) => void) {
+  override off<T extends PaymentWidgetEvent['detail']['type']>(
+    event: T,
+    listener: (event: Extract<PaymentWidgetEvent<TFlow>, { detail: { type: T } }>) => void
+  ) {
     super.off(event, listener);
   }
 

--- a/packages/payment-widget-web-sdk/src/types/base.ts
+++ b/packages/payment-widget-web-sdk/src/types/base.ts
@@ -7,6 +7,7 @@ import {
   type WidgetCompleteMessageType,
   type WidgetErrorMessageType,
   type WidgetLoadMessageType,
+  type WidgetMessageEvent,
   type WidgetReadyMessageType
 } from '@uphold/enterprise-widget-messaging-types';
 
@@ -14,48 +15,61 @@ import {
  * External API Types.
  */
 
+export type WidgetLoadEventType = WidgetLoadMessageType;
+export type WidgetReadyEventType = WidgetReadyMessageType;
 export type WidgetCompleteEventType = WidgetCompleteMessageType;
 export type WidgetCancelEventType = WidgetCancelMessageType;
 export type WidgetErrorEventType = WidgetErrorMessageType;
-export type WidgetLoadEventType = WidgetLoadMessageType;
-export type WidgetReadyEventType = WidgetReadyMessageType;
+
+export type WidgetLoadEventDetail = {
+  type: WidgetLoadEventType;
+};
+
+export type WidgetReadyEventDetail = {
+  type: WidgetReadyEventType;
+};
+
+export type WidgetCompleteEventDetail = {
+  type: WidgetCompleteEventType;
+};
+
+export type WidgetCancelEventDetail = {
+  type: WidgetCancelEventType;
+};
 
 export type WidgetErrorEventDetail = {
+  type: WidgetErrorEventType;
   error: string;
 };
 
-export interface WidgetCompleteEvent extends CustomEvent {
-  type: WidgetCompleteEventType;
-}
+export type ExtractMessageEventDataForType<
+  TMessageEvent extends WidgetMessageEvent,
+  TType extends TMessageEvent['data']['type']
+> = Extract<TMessageEvent, { data: { type: TType } }>['data'];
 
-export interface WidgetErrorEvent extends CustomEvent<WidgetErrorEventDetail> {
-  type: WidgetErrorEventType;
-}
+export type WidgetLoadEvent<TMessageEvent extends WidgetMessageEvent> = CustomEvent<
+  ExtractMessageEventDataForType<TMessageEvent, 'load'>
+>;
 
-export interface WidgetLoadEvent extends CustomEvent {
-  type: WidgetLoadEventType;
-}
+export type WidgetReadyEvent<TMessageEvent extends WidgetMessageEvent> = CustomEvent<
+  ExtractMessageEventDataForType<TMessageEvent, 'ready'>
+>;
+export type WidgetCompleteEvent<TMessageEvent extends WidgetMessageEvent> = CustomEvent<
+  ExtractMessageEventDataForType<TMessageEvent, 'complete'>
+>;
+export type WidgetCancelEvent<TMessageEvent extends WidgetMessageEvent> = CustomEvent<
+  ExtractMessageEventDataForType<TMessageEvent, 'cancel'>
+>;
+export type WidgetErrorEvent<TMessageEvent extends WidgetMessageEvent> = CustomEvent<
+  ExtractMessageEventDataForType<TMessageEvent, 'error'>
+>;
 
-export interface WidgetCancelEvent extends CustomEvent {
-  type: WidgetCancelEventType;
-}
-
-export interface WidgetReadyEvent extends CustomEvent {
-  type: WidgetReadyEventType;
-}
-
-export type WidgetEvent =
-  | WidgetCompleteEvent
-  | WidgetErrorEvent
-  | WidgetCancelEvent
-  | WidgetLoadEvent
-  | WidgetReadyEvent;
-
-export type EventByType<Event extends { type: string }, T extends Event['type']> = Event extends infer E
-  ? E extends { type: T }
-    ? E
-    : never
-  : never;
+export type WidgetEvent<TMessageEvent extends WidgetMessageEvent = WidgetMessageEvent> =
+  | WidgetLoadEvent<TMessageEvent>
+  | WidgetReadyEvent<TMessageEvent>
+  | WidgetCompleteEvent<TMessageEvent>
+  | WidgetCancelEvent<TMessageEvent>
+  | WidgetErrorEvent<TMessageEvent>;
 
 export type WidgetMountIframeOptions = Record<string, unknown>;
 

--- a/packages/payment-widget-web-sdk/src/types/payment-widget.ts
+++ b/packages/payment-widget-web-sdk/src/types/payment-widget.ts
@@ -1,26 +1,34 @@
 /**
- * Exports.
+ * Module dependencies.
  */
 
+import type { PaymentWidgetFlow, PaymentWidgetMessageEvent } from '@uphold/enterprise-widget-messaging-types';
 import type {
   WidgetCancelEvent,
-  WidgetCompleteEventType,
+  WidgetCompleteEvent,
   WidgetErrorEvent,
   WidgetLoadEvent,
   WidgetReadyEvent
 } from './base';
 
-export type PaymentWidgetCompleteEventDetail = {
-  externalAccountId: string;
-};
+/**
+ * Exports.
+ */
 
-export interface PaymentWidgetCompleteEvent extends CustomEvent<PaymentWidgetCompleteEventDetail> {
-  type: WidgetCompleteEventType;
-}
+export type PaymentWidgetLoadEvent = WidgetLoadEvent<PaymentWidgetMessageEvent>;
+export type PaymentWidgetReadyEvent = WidgetReadyEvent<PaymentWidgetMessageEvent>;
+export type PaymentWidgetCompleteEvent<TFlow extends PaymentWidgetFlow> = WidgetCompleteEvent<
+  PaymentWidgetMessageEvent<TFlow>
+>;
+export type PaymentWidgetCancelEvent = WidgetCancelEvent<PaymentWidgetMessageEvent>;
+export type PaymentWidgetErrorEvent = WidgetErrorEvent<PaymentWidgetMessageEvent>;
 
-export type PaymentWidgetEvent =
-  | PaymentWidgetCompleteEvent
-  | WidgetCancelEvent
-  | WidgetErrorEvent
-  | WidgetReadyEvent
-  | WidgetLoadEvent;
+// This type could simply be WidgetEvent<PaymentWidgetMessageEvent> but it would be
+// ugly for the consumers so we make the type definition a little more verbose than
+// it should so it can give a more pleasant visualization of the types.
+export type PaymentWidgetEvent<TFlow extends PaymentWidgetFlow = PaymentWidgetFlow> =
+  | PaymentWidgetLoadEvent
+  | PaymentWidgetReadyEvent
+  | PaymentWidgetCompleteEvent<TFlow>
+  | PaymentWidgetCancelEvent
+  | PaymentWidgetErrorEvent;

--- a/projects/widget-test-app/.env.sample
+++ b/projects/widget-test-app/.env.sample
@@ -1,6 +1,0 @@
-VITE_CLIENT_ID=
-VITE_CLIENT_SECRET=
-VITE_IMPERSONATE_USER_ID=
-VITE_PAYMENT_SESSION_URL_OVERRIDE=
-VITE_ENTERPRISE_CORE_API_BASE_URL=https://api.enterprise.sandbox.uphold.com/core
-VITE_ENTERPRISE_WIDGETS_API_BASE_URL=https://api.enterprise.sandbox.uphold.com/widgets

--- a/projects/widget-test-app/.gitignore
+++ b/projects/widget-test-app/.gitignore
@@ -1,0 +1,2 @@
+config.ts
+

--- a/projects/widget-test-app/README.md
+++ b/projects/widget-test-app/README.md
@@ -24,23 +24,20 @@ npm install
 
 To test the Payment Widget Web SDK in the browser, follow these steps:
 
-#### **Set up environment variables**
+#### **Set up configuration**
 
-Copy the `.env.sample` file to `.env` and set the values for the following variables:
+Copy the `config.sample.ts` file to `config.ts` and set the required values for the flow you want to test. Check the comments of that file for more information.
 
-- **VITE_CLIENT_ID**: The client ID used to obtain a token from the Enterprise API.
-- **VITE_CLIENT_SECRET**: The corresponding secret for the client ID.
-- **VITE_IMPERSONATE_USER_ID**: A user ID that will be impersonated in the Enterprise API calls.
-- **VITE_PAYMENT_SESSION_URL_OVERRIDE**: This will override the response from the "create payment widget session" request to allow running the payment widget locally. (Example: `http://localhost:8788`).
-- **VITE_ENTERPRISE_CORE_API_BASE_URL**: The base URL for all `Enterprise Core API` calls.
-- **VITE_ENTERPRISE_WIDGETS_API_BASE_URL**: The same as `VITE_ENTERPRISE_CORE_API_BASE_URL` but for the `Enterprise Widgets API` calls.
+> [!NOTE]
+> Except for `paymentWidgetSession.urlOverride`, all other values are required.
 
-> [!NOTE]  
-> Except for `VITE_PAYMENT_SESSION_URL_OVERRIDE`, all other values are required.
+#### Setup authorize flow (optional)
 
-#### Start the payment widget project
+If you want to test the `authorize` flow, you need to configure the create quote request body to be used to create the quote to authorize. To do so, inside the `config.ts` file set the values you want for the body in `flows.authorize.createQuoteBody` property. You can just paste the body from the postman collection to make it easier.
 
-Start the Payment Widget project and ensure it is listening at the URL specified by the `VITE_PAYMENT_SESSION_URL_OVERRIDE` environment variable in step 1.
+#### Start the payment widget project (optional)
+
+If you want to run the payment widget project locally, start it and ensure it is listening at the URL specified by the `paymentWidgetSession.urlOverride` property in `config.ts` file.
 
 #### Start the Widget Test App
 
@@ -52,15 +49,9 @@ npm run dev
 
 It will print the URL where the app is running, usually `http://localhost:8789`. Open this URL in your browser.
 
-##### Select the "Payment Widget" option
+##### Select the "Payment Widget" option and the desired flow
 
-Click the `"Payment Widget"` button to navigate to the `"Payment Widget SDK Test"` page. This will:
-
-Create a token with the Enterprise API using the client credentials provided in the `.env` file;
-Create a payment widget session and override the URL in the response with the value of `VITE_PAYMENT_SESSION_URL_OVERRIDE`, if specified;
-Instantiate the widget with the URL from the payment widget session.
-
-Enjoy testing!
+Click the `"Payment Widget"` button to navigate to the `"Payment Widget SDK Test"` page. That page will present the available flows you can test. Select the flow you desire by clicking on it and enjoy testing!
 
 ### Development
 

--- a/projects/widget-test-app/config.sample.ts
+++ b/projects/widget-test-app/config.sample.ts
@@ -1,0 +1,53 @@
+/**
+ * Export default config.
+ */
+
+export const config = {
+  enterpriseApi: {
+    apis: {
+      core: {
+        // Base url for the enterprise `core` API. (required)
+        baseUrl: '<core_api_base_url>'
+      },
+      widgets: {
+        // Base url for the enterprise `widgets` API. (required)
+        baseUrl: '<widgets_api_base_url>'
+      }
+    },
+    authentication: {
+      // Client ID used for authenticating against the API. (required)
+      clientId: '<client_id>',
+      // Corresponding client secret in plain-text. (required)
+      clientSecret: '<client_secret>',
+      // Value used for the header `X-On-Behalf-Of` in requests that require it. (required)
+      onBehalfOf: 'user <user_id>'
+    }
+  },
+  flows: {
+    authorize: {
+      // Body for the create quote request used in `authorize` flow. (Optional when flow is not `authorize`)
+      createQuoteBody: {
+        denomination: {
+          amount: '10',
+          asset: 'XRP',
+          target: 'origin'
+        },
+        destination: {
+          id: '<account_id>',
+          type: 'account'
+        },
+        origin: {
+          id: '<external_account_id>',
+          type: 'external_account'
+        }
+      }
+    }
+  },
+  paymentWidgetSession: {
+    // URL to override the response url from the payment widget session.
+    // required when you want to test the payment widget locally.
+    // Uncomment the line below to override the payment widget session's url
+    // to point to the local payment widget.
+    // urlOverride: 'http://localhost:8788'
+  }
+};

--- a/projects/widget-test-app/src/pages/payment-widget/payment-widget.css
+++ b/projects/widget-test-app/src/pages/payment-widget/payment-widget.css
@@ -56,3 +56,37 @@ h1 {
 .widget-container {
   flex: 1;
 }
+
+.button-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh; /* Full viewport height */
+}
+
+.action-button {
+  margin: 10px;
+  padding: 10px 20px;
+  font-size: 16px;
+  color: #fff;
+  background-color: #007bff;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  transition: background-color 0.3s ease;
+  text-align: center;
+  min-width: 200px;
+}
+
+.action-button:hover {
+  background-color: #0056b3;
+}
+
+.select-flow-text {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 20px;
+  color: #333;
+  text-align: center;
+}

--- a/projects/widget-test-app/src/shared/api/hooks/index.ts
+++ b/projects/widget-test-app/src/shared/api/hooks/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Exports.
+ */
+
+export * from './use-create-quote';
+export * from './use-create-token';

--- a/projects/widget-test-app/src/shared/api/hooks/use-create-quote.ts
+++ b/projects/widget-test-app/src/shared/api/hooks/use-create-quote.ts
@@ -1,0 +1,60 @@
+/**
+ * Module dependencies.
+ */
+
+import { type CreateQuoteData, type CreateQuoteOptions, createQuote as createQuoteRequest } from '../../api/requests';
+import { config } from '../../../../config';
+import { useCreateToken } from './use-create-token';
+import { useState } from 'react';
+
+/**
+ * Configs.
+ */
+
+const { createQuoteBody } = config.flows.authorize;
+const { onBehalfOf } = config.enterpriseApi.authentication;
+
+/**
+ * Exports.
+ */
+
+export const useCreateQuote = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const { createToken } = useCreateToken();
+
+  const createQuote = async (createQuoteData?: CreateQuoteData, createQuoteOptions?: CreateQuoteOptions) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      if (!createQuoteOptions) {
+        const token = await createToken();
+
+        createQuoteOptions = {
+          accessToken: token.access_token,
+          onBehalfOf
+        };
+      }
+
+      if (!createQuoteData) {
+        createQuoteData = createQuoteBody as CreateQuoteData;
+      }
+
+      return await createQuoteRequest(createQuoteData, createQuoteOptions);
+    } catch (e) {
+      setError(e as Error);
+
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    createQuote,
+    error,
+    isLoading
+  };
+};

--- a/projects/widget-test-app/src/shared/api/hooks/use-create-token.ts
+++ b/projects/widget-test-app/src/shared/api/hooks/use-create-token.ts
@@ -1,0 +1,43 @@
+/**
+ * Module dependencies.
+ */
+
+import { type CreateTokenData, createToken as createTokenRequest } from '../../api/requests';
+import { config } from '../../../../config';
+import { useState } from 'react';
+
+/**
+ * Exports.
+ */
+
+export const useCreateToken = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const createToken = async (createTokenData?: CreateTokenData) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      if (!createTokenData) {
+        const { clientId, clientSecret } = config.enterpriseApi.authentication;
+
+        createTokenData = { clientId, clientSecret };
+      }
+
+      return await createTokenRequest(createTokenData as CreateTokenData);
+    } catch (e) {
+      setError(e as Error);
+
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    createToken,
+    error,
+    isLoading
+  };
+};

--- a/projects/widget-test-app/src/shared/api/index.ts
+++ b/projects/widget-test-app/src/shared/api/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './requests';
+export * from './hooks';

--- a/projects/widget-test-app/src/shared/api/requests/create-payment-session.ts
+++ b/projects/widget-test-app/src/shared/api/requests/create-payment-session.ts
@@ -3,6 +3,13 @@
  */
 
 import type { PaymentWidgetFlow } from '@uphold/enterprise-widget-messaging-types';
+import { config } from '../../../../config';
+
+/**
+ * Configs.
+ */
+
+const widgetsApiBaseUrl = config.enterpriseApi.apis.widgets.baseUrl;
 
 /**
  * Exports.
@@ -15,22 +22,22 @@ export type CreatePaymentSessionData = {
 
 export type CreatePaymentSessionOptions = {
   accessToken: string;
-  impersonateUserId?: string;
-  urlOverride?: string;
+  onBehalfOf?: string;
+  paymentSessionUrlOverride?: string;
 };
 
 export const createPaymentSession = async (
   createPaymentSessionData: CreatePaymentSessionData,
   options: CreatePaymentSessionOptions
 ) => {
-  const response = await fetch(`${import.meta.env.VITE_ENTERPRISE_WIDGETS_API_BASE_URL}/payment/sessions`, {
+  const response = await fetch(`${widgetsApiBaseUrl}/payment/sessions`, {
     body: JSON.stringify({
       ...createPaymentSessionData
     }),
     headers: {
       Authorization: `Bearer ${options.accessToken}`,
       'Content-Type': 'application/json',
-      'X-On-Behalf-Of': `user ${options.impersonateUserId}`
+      'X-On-Behalf-Of': options.onBehalfOf ?? ''
     },
     method: 'POST'
   });
@@ -40,8 +47,8 @@ export const createPaymentSession = async (
 
     const paymentSession = responseBody.session;
 
-    if (options.urlOverride) {
-      paymentSession.url = options.urlOverride;
+    if (options.paymentSessionUrlOverride) {
+      paymentSession.url = options.paymentSessionUrlOverride;
     }
 
     return paymentSession;

--- a/projects/widget-test-app/src/shared/api/requests/create-quote.ts
+++ b/projects/widget-test-app/src/shared/api/requests/create-quote.ts
@@ -1,0 +1,62 @@
+/**
+ * Module dependencies.
+ */
+
+import { config } from '../../../../config';
+
+/**
+ * Configs.
+ */
+
+const coreApiBaseUrl = config.enterpriseApi.apis.core.baseUrl;
+
+/**
+ * Exports.
+ */
+
+export type CreateQuoteOptions = {
+  accessToken: string;
+  onBehalfOf?: string;
+};
+
+export type CreateQuoteData = {
+  origin: {
+    type: 'account' | 'external-account';
+    id: string;
+  };
+  destination: {
+    type: 'account' | 'external-account';
+    id: string;
+  };
+  denomination: {
+    asset: string;
+    amount: string;
+    target: 'origin' | 'destination';
+  };
+};
+
+export const createQuote = async (createQuoteData: CreateQuoteData, options: CreateQuoteOptions) => {
+  const response = await fetch(`${coreApiBaseUrl}/transactions/quote`, {
+    body: JSON.stringify({
+      ...createQuoteData
+    }),
+    headers: {
+      Authorization: `Bearer ${options.accessToken}`,
+      'Content-Type': 'application/json',
+      'X-On-Behalf-Of': options.onBehalfOf ?? ''
+    },
+    method: 'POST'
+  });
+
+  if (response.ok) {
+    const responseBody = await response.json();
+
+    const { quote } = responseBody;
+
+    return quote;
+  }
+
+  throw new Error(
+    `Request to create quote failed. HTTP status code: ${response.status}, text: ${await response.text()}`
+  );
+};

--- a/projects/widget-test-app/src/shared/api/requests/create-token.ts
+++ b/projects/widget-test-app/src/shared/api/requests/create-token.ts
@@ -1,4 +1,16 @@
 /**
+ * Module dependencies.
+ */
+
+import { config } from '../../../../config';
+
+/**
+ * Configs.
+ */
+
+const coreApiBaseUrl = config.enterpriseApi.apis.core.baseUrl;
+
+/**
  * Exports.
  */
 
@@ -10,7 +22,7 @@ export type CreateTokenData = {
 export const createToken = async ({ clientId, clientSecret }: CreateTokenData) => {
   const credentials = btoa(`${clientId}:${clientSecret}`);
 
-  const response = await fetch(`${import.meta.env.VITE_ENTERPRISE_CORE_API_BASE_URL}/oauth2/token`, {
+  const response = await fetch(`${coreApiBaseUrl}/oauth2/token`, {
     body: new URLSearchParams({
       grant_type: 'client_credentials',
       scope: '*'

--- a/projects/widget-test-app/src/shared/api/requests/index.ts
+++ b/projects/widget-test-app/src/shared/api/requests/index.ts
@@ -4,3 +4,4 @@
 
 export * from './create-payment-session';
 export * from './create-token';
+export * from './create-quote';

--- a/projects/widget-test-app/src/shared/react/payment-widget-session/use-flow-data.ts
+++ b/projects/widget-test-app/src/shared/react/payment-widget-session/use-flow-data.ts
@@ -1,0 +1,33 @@
+/**
+ * Module dependencies.
+ */
+
+import type { PaymentWidgetFlow } from '@uphold/enterprise-widget-messaging-types';
+import { useCreateQuote } from '../../api';
+
+/**
+ * Exports.
+ */
+
+export const useFlowData = () => {
+  const { createQuote, error: createQuoteError, isLoading: isCreatingQuote } = useCreateQuote();
+
+  const error = createQuoteError;
+  const isLoading = isCreatingQuote;
+
+  const loadFlowData = async (flow: PaymentWidgetFlow) => {
+    if (flow !== 'authorize') {
+      return {};
+    }
+
+    const quote = await createQuote();
+
+    return { quoteId: quote.id };
+  };
+
+  return {
+    error,
+    isLoading,
+    loadFlowData
+  };
+};

--- a/projects/widget-test-app/src/vite-env.d.ts
+++ b/projects/widget-test-app/src/vite-env.d.ts
@@ -1,13 +1,7 @@
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-  readonly VITE_CLIENT_ID: string;
-  readonly VITE_CLIENT_SECRET: string;
-  readonly VITE_IMPERSONATE_USER_ID: string;
-  readonly VITE_PAYMENT_SESSION_URL_OVERRIDE: string;
-  readonly VITE_ENTERPRISE_CORE_API_BASE_URL: string;
-  readonly VITE_ENTERPRISE_WIDGETS_API_BASE_URL: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface ImportMetaEnv {}
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;

--- a/projects/widget-test-app/vite.config.ts
+++ b/projects/widget-test-app/vite.config.ts
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-import { UserConfig, defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import { reactRouter } from '@react-router/dev/vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
@@ -10,15 +10,10 @@ import tsconfigPaths from 'vite-tsconfig-paths';
  * Export config.
  */
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '');
-
-  const config: UserConfig = {
-    plugins: [!env.VITEST && reactRouter(), tsconfigPaths()],
-    server: {
-      port: 8789
-    }
-  };
-
-  return config;
+export default defineConfig({
+  // eslint-disable-next-line no-process-env
+  plugins: [!process.env.VITEST && reactRouter(), tsconfigPaths()],
+  server: {
+    port: 8789
+  }
 });


### PR DESCRIPTION
### Description

This adds support for the `authorize` flow in test app.
The test page app was refactored in other to support
multiple flows easier. Also, configs are now centralized
under `config` folder instead of using environment variables.

Typings of the `PaymentWidget` class were also changed
to reflect the breaking change for the `complete` event
and now it accepts a type parameter that allows to specify
the expected flow returning value for the `complete` event.

### Related issues

N/A

### Deploy notes

This needs an update to `@uphold/widget-messaging-types` package to reflect the
new types supported by the payment widget.
