### PR TITLE
Replace reliability team in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, they will
 # be requested for review when someone opens a pull request.
-* @uphold/engineering-leadership @uphold/reliability @uphold/enterprise
+* @uphold/engineering-leadership @uphold/reliability-codeowners @uphold/enterprise
 
 # Order is important; the last matching pattern takes the most
 # precedence. Rules are not addictive, meaning people or teams


### PR DESCRIPTION
### Description

This PR replaces the reliability team in codeowners file.

### Related issues

N/A.

### Deploy notes

N/A.
