### PR TITLE
Add support for `force_repaint` message

### DIFF
--- a/.github/workflows/tests.payment-widget-web-sdk.yaml
+++ b/.github/workflows/tests.payment-widget-web-sdk.yaml
@@ -31,7 +31,7 @@ jobs:
         run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
       - name: Restore NPM cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-arc-npm-${{ hashFiles('**/package-lock.json') }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3163,6 +3163,11 @@
       "resolved": "packages/travel-rule-widget-web-sdk",
       "link": true
     },
+    "node_modules/@uphold/enterprise-widget-messaging-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.13.0.tgz",
+      "integrity": "sha512-326ns/L+KTDRfSG1adJ51FTiY3TtMsAVOMaPgb5vOfJ4PmSUuVWnLsRelRS8lph+w8Z3J6w9V3a1Uc4FqhPz2A=="
+    },
     "node_modules/@uphold/enterprise-widget-sdk-core": {
       "resolved": "packages/core",
       "link": true
@@ -11126,16 +11131,11 @@
       "name": "@uphold/enterprise-widget-sdk-core",
       "version": "0.7.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.12.0"
+        "@uphold/enterprise-widget-messaging-types": "^0.13.0"
       },
       "devDependencies": {
         "jsdom": "^27.4.0"
       }
-    },
-    "packages/core/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.12.0.tgz",
-      "integrity": "sha512-Kgybh5yQ/Xdw3lDkiX7cXuI/e4Q0RJr/NGqVu/rHAfYHu8Kca/B5Yjh7GMr5VQgjQBfSowTFzZ2PpORJKcYBLA=="
     },
     "packages/payment-widget-js-sdk": {
       "name": "@uphold/enterprise-payment-widget-js-sdk",
@@ -11149,27 +11149,17 @@
       "name": "@uphold/enterprise-payment-widget-web-sdk",
       "version": "0.9.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.12.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.13.0",
         "@uphold/enterprise-widget-sdk-core": "^0.7.0"
       }
-    },
-    "packages/payment-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.12.0.tgz",
-      "integrity": "sha512-Kgybh5yQ/Xdw3lDkiX7cXuI/e4Q0RJr/NGqVu/rHAfYHu8Kca/B5Yjh7GMr5VQgjQBfSowTFzZ2PpORJKcYBLA=="
     },
     "packages/travel-rule-widget-web-sdk": {
       "name": "@uphold/enterprise-travel-rule-widget-web-sdk",
       "version": "0.5.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.12.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.13.0",
         "@uphold/enterprise-widget-sdk-core": "^0.7.0"
       }
-    },
-    "packages/travel-rule-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.12.0.tgz",
-      "integrity": "sha512-Kgybh5yQ/Xdw3lDkiX7cXuI/e4Q0RJr/NGqVu/rHAfYHu8Kca/B5Yjh7GMr5VQgjQBfSowTFzZ2PpORJKcYBLA=="
     },
     "packages/widget-messaging-types": {
       "name": "@uphold/enterprise-widget-messaging-types",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.12.0"
+    "@uphold/enterprise-widget-messaging-types": "^0.13.0"
   },
   "devDependencies": {
     "jsdom": "^27.4.0"

--- a/packages/core/src/widget.test.ts
+++ b/packages/core/src/widget.test.ts
@@ -213,6 +213,59 @@ describe('Widget', () => {
     `);
   });
 
+  it('should handle `force_repaint` message by temporarily setting iframe opacity to 0.99 then back to 1', () => {
+    vi.useFakeTimers();
+
+    const widget = new Widget(session);
+    const element = document.createElement('div');
+
+    widget.mountIframe(element);
+
+    const iframe = element.querySelector('iframe') as HTMLIFrameElement;
+
+    const messageEvent = new MessageEvent('message', {
+      data: { type: 'force_repaint' },
+      origin: session.url
+    });
+
+    window.dispatchEvent(messageEvent);
+
+    expect(iframe.style.opacity).toBe('0.99');
+
+    vi.runAllTimers();
+
+    expect(iframe.style.opacity).toBe('1');
+
+    vi.useRealTimers();
+  });
+
+  it('should not set opacity back to 1 on `force_repaint` if iframe is unmounted before the timeout fires', () => {
+    vi.useFakeTimers();
+
+    const widget = new Widget(session);
+    const element = document.createElement('div');
+
+    widget.mountIframe(element);
+
+    const iframe = element.querySelector('iframe') as HTMLIFrameElement;
+
+    const messageEvent = new MessageEvent('message', {
+      data: { type: 'force_repaint' },
+      origin: session.url
+    });
+
+    window.dispatchEvent(messageEvent);
+
+    expect(iframe.style.opacity).toBe('0.99');
+
+    widget.unmount();
+    vi.runAllTimers();
+
+    expect(iframe.style.opacity).toBe('0.99');
+
+    vi.useRealTimers();
+  });
+
   it('should ignore messages from unknown origins', () => {
     const widget = new Widget(session, { debug: true });
 

--- a/packages/core/src/widget.ts
+++ b/packages/core/src/widget.ts
@@ -167,6 +167,27 @@ class Widget<
     this[logSymbol].log('[Widget -> Host] ', event.data);
 
     switch (event.data.type) {
+      // This is to force a repaint of the iframe to address
+      // a bug that happens when using view transitions API
+      // while running the widget in a WKWebView on iOS.
+      case 'force_repaint': {
+        if (!this.#iframe) {
+          break;
+        }
+
+        this.#iframe.style.opacity = '0.99';
+
+        setTimeout(() => {
+          if (!this.#iframe) {
+            return;
+          }
+
+          this.#iframe.style.opacity = '1';
+        }, 0);
+
+        break;
+      }
+
       case 'load': {
         const widgetInitMessage = {
           ...this.session,

--- a/packages/payment-widget-web-sdk/package.json
+++ b/packages/payment-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.12.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.13.0",
     "@uphold/enterprise-widget-sdk-core": "^0.7.0"
   }
 }

--- a/packages/travel-rule-widget-web-sdk/package.json
+++ b/packages/travel-rule-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.12.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.13.0",
     "@uphold/enterprise-widget-sdk-core": "^0.7.0"
   }
 }


### PR DESCRIPTION
### Description

This adds support for `force_repaint` message from the widgets to
fix the problem when using view transitions API to animate the transitions
when navigating to different routes in react-router with iOS WKWebView,
where it would not render the updated DOM to the screen.

### Related issues

N/A

### Deploy notes

N/A
