### PR TITLE
Remove vitest concurrency env vars from test workflows

### DIFF
--- a/.github/workflows/tests.kyc-widget-web-sdk.yaml
+++ b/.github/workflows/tests.kyc-widget-web-sdk.yaml
@@ -47,7 +47,4 @@ jobs:
         run: npm run typecheck --workspace $NPM_WORKSPACE
 
       - name: Run tests
-        env:
-          VITEST_MAX_THREADS: 4
-          VITEST_MIN_THREADS: 1
         run: npm run test --workspace $NPM_WORKSPACE

--- a/.github/workflows/tests.payment-widget-web-sdk.yaml
+++ b/.github/workflows/tests.payment-widget-web-sdk.yaml
@@ -47,7 +47,4 @@ jobs:
         run: npm run typecheck --workspace $NPM_WORKSPACE
 
       - name: Run tests
-        env:
-          VITEST_MAX_THREADS: 4
-          VITEST_MIN_THREADS: 1
         run: npm run test --workspace $NPM_WORKSPACE


### PR DESCRIPTION
### Description

These CI test workflows manually capped vitest concurrency via `VITEST_MAX_THREADS` / `VITEST_MIN_THREADS`. This removes those environment variables so vitest uses its default parallelism based on the available CPUs.

Impacted areas: CI test workflow(s) only (`tests.kyc-widget-web-sdk.yaml` and `tests.payment-widget-web-sdk.yaml`).

Steps to test: CI runs the affected test workflow(s) on this PR.

> **Note:** The proper fix is [uphold/eks@e9bd661](https://github.com/uphold/eks/commit/e9bd6615b823a71b4c030b6b87b2f1e3f209525c), which addresses the underlying issue and makes this change unnecessary.

### Related issues

N/A

### Deploy notes

N/A
