### PR TITLE
Remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
### Description

Removes the repository-level `.npmrc`, whose sole content was:

```
//registry.npmjs.org/:_authToken=${NPM_TOKEN}
```

This file configured an npm registry auth token (via the `NPM_TOKEN` env var) for publishing.

> [!NOTE]
> If this repo publishes to npm via CI, ensure the registry authentication is provided through another mechanism (e.g. the publish workflow itself) so publishing is not broken by this removal.

### Related issues

N/A

### Deploy notes

N/A