### PR TITLE
Add PayPal/Venmo/Apple-Pay authorize flow support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-!.vscode
+.vscode
 **/.chart/charts
 **/coverage
 **/node_modules

--- a/projects/widget-test-app/config.sample.ts
+++ b/projects/widget-test-app/config.sample.ts
@@ -52,6 +52,48 @@ export const config = {
               type: 'external_account'
             }
           }
+        },
+        'paypal-authorize': {
+          // Example `authorize` configuration for the `paypal` flow.
+          // Body for the create quote request used in `paypal-authorize` flow.
+          // Creates a quote with a PayPal APM origin, then fetches a Braintree client token
+          // and riskCorrelationId automatically before launching the authorize widget.
+          createQuoteBody: {
+            denomination: {
+              amount: '50',
+              asset: 'USD',
+              target: 'origin'
+            },
+            destination: {
+              id: '<account_id>',
+              type: 'account'
+            },
+            origin: {
+              method: 'paypal',
+              type: 'apm'
+            }
+          }
+        },
+        'venmo-authorize': {
+          // Example `authorize` configuration for the `venmo` flow.
+          // Body for the create quote request used in `venmo-authorize` flow.
+          // Creates a quote with a Venmo APM origin, then fetches a Braintree client token
+          // and riskCorrelationId automatically before launching the authorize widget.
+          createQuoteBody: {
+            denomination: {
+              amount: '50',
+              asset: 'USD',
+              target: 'origin'
+            },
+            destination: {
+              id: '<account_id>',
+              type: 'account'
+            },
+            origin: {
+              method: 'venmo',
+              type: 'apm'
+            }
+          }
         }
       },
       session: {

--- a/projects/widget-test-app/src/shared/api/requests/create-quote.ts
+++ b/projects/widget-test-app/src/shared/api/requests/create-quote.ts
@@ -19,19 +19,27 @@ export type CreateQuoteOptions = {
   onBehalfOf?: string;
 };
 
+type AccountTarget = {
+  type: 'account' | 'external-account';
+  id: string;
+};
+
+type CryptoAddressTarget = {
+  type: 'crypto-address';
+  network: string;
+  address: string;
+};
+
+type ApmTarget = {
+  type: 'apm';
+  method: 'paypal' | 'venmo';
+};
+
+type QuoteTarget = AccountTarget | CryptoAddressTarget | ApmTarget;
+
 export type CreateQuoteData = {
-  origin: {
-    type: 'account' | 'external-account' | 'crypto-address';
-    id?: string;
-    network?: string;
-    address?: string;
-  };
-  destination: {
-    type: 'account' | 'external-account' | 'crypto-address';
-    id?: string;
-    network?: string;
-    address?: string;
-  };
+  origin: QuoteTarget;
+  destination: QuoteTarget;
   denomination: {
     asset: string;
     amount: string;

--- a/projects/widget-test-app/src/shared/react/payment-widget-session/use-flow-data.ts
+++ b/projects/widget-test-app/src/shared/react/payment-widget-session/use-flow-data.ts
@@ -22,9 +22,13 @@ export const useFlowData = () => {
     }
 
     const createQuoteBody = config.widgets.payment.flows.authorize.createQuoteBody as CreateQuoteData;
-    const quote = await createQuote(createQuoteBody);
 
-    return { quoteId: quote.id };
+    const { id: quoteId, requirements } = await createQuote(createQuoteBody);
+
+    return {
+      quoteId,
+      requirements
+    };
   };
 
   return {


### PR DESCRIPTION
### Description

Adds support for APM authorize flow in the widget test app.

- Adds a `paypal-authorize` flow config to `config.sample.ts`, which creates a quote with a PayPal APM origin and then fetches a Braintree client token and `riskCorrelationId` before launching the authorize widget.
- Extends `CreateQuoteOptions` to support `apm` origin/destination types and an optional `method` field.
- Updates `useFlowData` to derive the payment `method` (`paypal` / `venmo` / `apple-pay`) from the quote body's APM origin and return it alongside the `quoteId`.

### Related issues

- https://uphold.atlassian.net/browse/WL-2119
- https://uphold.atlassian.net/browse/WL-2096

### Deploy notes

N/A