### PR TITLE
Add support for custom theming on the payment widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3167,6 +3167,11 @@
       "resolved": "packages/travel-rule-widget-web-sdk",
       "link": true
     },
+    "node_modules/@uphold/enterprise-widget-messaging-types": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.17.0.tgz",
+      "integrity": "sha512-s+THblW0CA5ePLoTyNwM4Ya4frf/pSEGsBQZCVQa2TSun4DDxGy67lS0PCWYpMyqx5aKUrlvBdQkaUpY05h8WQ=="
+    },
     "node_modules/@uphold/enterprise-widget-sdk-core": {
       "resolved": "packages/core",
       "link": true
@@ -11130,29 +11135,19 @@
       "name": "@uphold/enterprise-widget-sdk-core",
       "version": "0.11.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.16.0"
+        "@uphold/enterprise-widget-messaging-types": "^0.17.0"
       },
       "devDependencies": {
         "jsdom": "^27.4.0"
       }
     },
-    "packages/core/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.16.0.tgz",
-      "integrity": "sha512-af9TVMvSM/Ocx+ca6dv8t2pcGqk9Nk3UFyObPCahx3jutAvrxOcJLapMBtlThggf4ttSlcbO6Ub37Z1j0MLNBg=="
-    },
     "packages/kyc-widget-web-sdk": {
       "name": "@uphold/enterprise-kyc-widget-web-sdk",
       "version": "0.2.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.16.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.17.0",
         "@uphold/enterprise-widget-sdk-core": "^0.11.0"
       }
-    },
-    "packages/kyc-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.16.0.tgz",
-      "integrity": "sha512-af9TVMvSM/Ocx+ca6dv8t2pcGqk9Nk3UFyObPCahx3jutAvrxOcJLapMBtlThggf4ttSlcbO6Ub37Z1j0MLNBg=="
     },
     "packages/payment-widget-js-sdk": {
       "name": "@uphold/enterprise-payment-widget-js-sdk",
@@ -11166,27 +11161,17 @@
       "name": "@uphold/enterprise-payment-widget-web-sdk",
       "version": "0.12.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.16.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.17.0",
         "@uphold/enterprise-widget-sdk-core": "^0.11.0"
       }
-    },
-    "packages/payment-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.16.0.tgz",
-      "integrity": "sha512-af9TVMvSM/Ocx+ca6dv8t2pcGqk9Nk3UFyObPCahx3jutAvrxOcJLapMBtlThggf4ttSlcbO6Ub37Z1j0MLNBg=="
     },
     "packages/travel-rule-widget-web-sdk": {
       "name": "@uphold/enterprise-travel-rule-widget-web-sdk",
       "version": "0.5.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.16.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.17.0",
         "@uphold/enterprise-widget-sdk-core": "^0.11.0"
       }
-    },
-    "packages/travel-rule-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.16.0.tgz",
-      "integrity": "sha512-af9TVMvSM/Ocx+ca6dv8t2pcGqk9Nk3UFyObPCahx3jutAvrxOcJLapMBtlThggf4ttSlcbO6Ub37Z1j0MLNBg=="
     },
     "packages/widget-messaging-types": {
       "name": "@uphold/enterprise-widget-messaging-types",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.16.0"
+    "@uphold/enterprise-widget-messaging-types": "^0.17.0"
   },
   "devDependencies": {
     "jsdom": "^27.4.0"

--- a/packages/core/src/types/base.ts
+++ b/packages/core/src/types/base.ts
@@ -11,14 +11,21 @@ import type {
   WidgetErrorMessageEventData,
   WidgetErrorMessageType,
   WidgetMessageEvent,
-  WidgetReadyMessageType
+  WidgetReadyMessageType,
+  WidgetThemeOption
 } from '@uphold/enterprise-widget-messaging-types';
 
 /**
  * External API Types.
  */
 
-export type { WidgetError, WidgetErrorMessageEventData, WidgetCompleteMessageEventData, WidgetCancelMessageEventData };
+export type {
+  WidgetError,
+  WidgetErrorMessageEventData,
+  WidgetCompleteMessageEventData,
+  WidgetCancelMessageEventData,
+  WidgetThemeOption
+};
 
 export type WidgetReadyEventType = WidgetReadyMessageType;
 export type WidgetCompleteEventType = WidgetCompleteMessageType;
@@ -73,7 +80,5 @@ export type WidgetMountIframeOptions = Record<string, unknown>;
 
 export type WidgetOptions = {
   debug?: boolean;
-  theme?: {
-    appearance?: 'light' | 'dark';
-  };
+  theme?: WidgetThemeOption;
 };

--- a/packages/core/src/widget.test.ts
+++ b/packages/core/src/widget.test.ts
@@ -92,6 +92,30 @@ describe('Widget', () => {
     expect(widget.session.url).toBe(session.url);
   });
 
+  it('should not add theme properties other than appearance to the iframe src', () => {
+    const widget = new Widget(session, {
+      theme: {
+        appearance: 'dark',
+        background: { dark: '#111113', light: '#edf2ed' },
+        components: {
+          button: { borderRadius: '999px' },
+          card: { borderRadius: '10px' },
+          input: { borderRadius: '8px' }
+        },
+        emphasisForeground: { dark: '#FFFFFF', light: '#000000' },
+        fontFamily: 'Helvetica',
+        foreground: { dark: '#FFFFFF', light: '#000000' },
+        primary: '#16cb3e',
+        primaryForeground: { dark: '#111111', light: '#FFFFFF' }
+      }
+    });
+    const element = document.createElement('div');
+
+    widget.mountIframe(element);
+
+    expect(element.querySelector('iframe')?.getAttribute('src')).toBe('https://localhost:5000/?theme_appearance=dark');
+  });
+
   it('should not add theme_appearance to the iframe src when options.theme.appearance is not set', () => {
     const widget = new Widget(session, { theme: {} });
     const element = document.createElement('div');

--- a/packages/kyc-widget-web-sdk/package.json
+++ b/packages/kyc-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.16.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.17.0",
     "@uphold/enterprise-widget-sdk-core": "^0.11.0"
   }
 }

--- a/packages/payment-widget-web-sdk/package.json
+++ b/packages/payment-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.16.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.17.0",
     "@uphold/enterprise-widget-sdk-core": "^0.11.0"
   }
 }

--- a/packages/payment-widget-web-sdk/src/payment-widget.ts
+++ b/packages/payment-widget-web-sdk/src/payment-widget.ts
@@ -74,6 +74,45 @@ class PaymentWidget<TFlow extends PaymentWidgetFlow = PaymentWidgetFlow> extends
    * const paymentWidget = new PaymentWidget(session, options);
    * ```
    *
+   * ### Advanced Usage with Theme:
+   * You can optionally define a theme to customize the widget's appearance using the `options` parameter:
+   *
+   * ```typescript
+   * const session = { url: 'https://example.com' };
+   * const options = {
+   *   theme: {
+   *     appearance: 'light',
+   *     background: {
+   *       dark: '#111113',
+   *       light: '#edf2ed'
+   *     },
+   *     components: {
+   *       button: { borderRadius: '999px' },
+   *       card: { borderRadius: '10px' },
+   *       input: { borderRadius: '8px' }
+   *     },
+   *     fontFamily: 'Helvetica',
+   *     foreground: {
+   *       dark: '#FFFFFF',
+   *       light: '#000000'
+   *     },
+   *     primary: {
+   *       dark: '#16cb3e',
+   *       light: '#0c2801'
+   *     },
+   *     primaryForeground: {
+   *       dark: '#111111',
+   *       light: '#FFFFFF'
+   *     },
+   *     emphasisForeground: {
+   *       dark: '#FFFFFF',
+   *       light: '#000000'
+   *     }
+   *   }
+   * };
+   * const paymentWidget = new PaymentWidget(session, options);
+   * ```
+   *
    * @param session The session object containing the configuration details for the widget.
    * This includes the session URL and any other data required to initialize the widget.
    */

--- a/packages/travel-rule-widget-web-sdk/package.json
+++ b/packages/travel-rule-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.16.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.17.0",
     "@uphold/enterprise-widget-sdk-core": "^0.11.0"
   }
 }


### PR DESCRIPTION
### Description

Adds support for richer theme customization on the widgets, as requested for the payment widget.

### Related issues

[WL-1792](https://uphold.atlassian.net/browse/WL-1792)

### Dependencies ⚠️ 
[PR #199](https://github.com/uphold/enterprise-widget/pull/199)

[WL-1792]: https://uphold.atlassian.net/browse/WL-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ