### PR TITLE
Bump widget-sdk-core to v0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11146,7 +11146,15 @@
       "version": "0.2.0",
       "dependencies": {
         "@uphold/enterprise-widget-messaging-types": "^0.17.0",
-        "@uphold/enterprise-widget-sdk-core": "^0.11.0"
+        "@uphold/enterprise-widget-sdk-core": "^0.12.0"
+      }
+    },
+    "packages/kyc-widget-web-sdk/node_modules/@uphold/enterprise-widget-sdk-core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-sdk-core/-/enterprise-widget-sdk-core-0.12.0.tgz",
+      "integrity": "sha512-qDZWD+7CT4CPjCQwaaen6IYcDxNvlmfdxQiDJSmfROG3UxaxJRuSFuqmMfLJ5o/SDv9sgz9ggybmhcErxJRUFw==",
+      "dependencies": {
+        "@uphold/enterprise-widget-messaging-types": "^0.17.0"
       }
     },
     "packages/kyc-widget-web-sdk/node_modules/@uphold/enterprise-widget-sdk-core": {
@@ -11175,7 +11183,15 @@
       "version": "0.12.0",
       "dependencies": {
         "@uphold/enterprise-widget-messaging-types": "^0.17.0",
-        "@uphold/enterprise-widget-sdk-core": "^0.11.0"
+        "@uphold/enterprise-widget-sdk-core": "^0.12.0"
+      }
+    },
+    "packages/payment-widget-web-sdk/node_modules/@uphold/enterprise-widget-sdk-core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-sdk-core/-/enterprise-widget-sdk-core-0.12.0.tgz",
+      "integrity": "sha512-qDZWD+7CT4CPjCQwaaen6IYcDxNvlmfdxQiDJSmfROG3UxaxJRuSFuqmMfLJ5o/SDv9sgz9ggybmhcErxJRUFw==",
+      "dependencies": {
+        "@uphold/enterprise-widget-messaging-types": "^0.17.0"
       }
     },
     "packages/payment-widget-web-sdk/node_modules/@uphold/enterprise-widget-sdk-core": {
@@ -11196,7 +11212,15 @@
       "version": "0.5.0",
       "dependencies": {
         "@uphold/enterprise-widget-messaging-types": "^0.17.0",
-        "@uphold/enterprise-widget-sdk-core": "^0.11.0"
+        "@uphold/enterprise-widget-sdk-core": "^0.12.0"
+      }
+    },
+    "packages/travel-rule-widget-web-sdk/node_modules/@uphold/enterprise-widget-sdk-core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-sdk-core/-/enterprise-widget-sdk-core-0.12.0.tgz",
+      "integrity": "sha512-qDZWD+7CT4CPjCQwaaen6IYcDxNvlmfdxQiDJSmfROG3UxaxJRuSFuqmMfLJ5o/SDv9sgz9ggybmhcErxJRUFw==",
+      "dependencies": {
+        "@uphold/enterprise-widget-messaging-types": "^0.17.0"
       }
     },
     "packages/travel-rule-widget-web-sdk/node_modules/@uphold/enterprise-widget-sdk-core": {


### PR DESCRIPTION
### Description

Bump `widget-sdk-core` to v`0.12.0`

### Related issues

[WL-1792](https://uphold.atlassian.net/browse/WL-1792)

[WL-1792]: https://uphold.atlassian.net/browse/WL-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ