### PR TITLE
Update TravelRuleWidgetOptions type and README

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3167,11 +3167,6 @@
       "resolved": "packages/travel-rule-widget-web-sdk",
       "link": true
     },
-    "node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.17.0.tgz",
-      "integrity": "sha512-s+THblW0CA5ePLoTyNwM4Ya4frf/pSEGsBQZCVQa2TSun4DDxGy67lS0PCWYpMyqx5aKUrlvBdQkaUpY05h8WQ=="
-    },
     "node_modules/@uphold/enterprise-widget-sdk-core": {
       "resolved": "packages/core",
       "link": true
@@ -11135,99 +11130,55 @@
       "name": "@uphold/enterprise-widget-sdk-core",
       "version": "0.12.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.17.0"
+        "@uphold/enterprise-widget-messaging-types": "^0.18.0"
       },
       "devDependencies": {
         "jsdom": "^27.4.0"
       }
     },
+    "packages/core/node_modules/@uphold/enterprise-widget-messaging-types": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.18.0.tgz",
+      "integrity": "sha512-kHy5HS38QFoneY20eZSunHmQhN1R8fzHibSsIUYCk1TnPgzjJGH47oYklxwN3HBPVDG1ns118WBLogAp1uDpOQ=="
+    },
     "packages/kyc-widget-web-sdk": {
       "name": "@uphold/enterprise-kyc-widget-web-sdk",
       "version": "0.2.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.17.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.18.0",
         "@uphold/enterprise-widget-sdk-core": "^0.12.0"
       }
     },
-    "packages/payment-widget-js-sdk": {
-      "name": "@uphold/enterprise-payment-widget-js-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "../widget-messaging-types"
-      }
+    "packages/kyc-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.18.0.tgz",
+      "integrity": "sha512-kHy5HS38QFoneY20eZSunHmQhN1R8fzHibSsIUYCk1TnPgzjJGH47oYklxwN3HBPVDG1ns118WBLogAp1uDpOQ=="
     },
     "packages/payment-widget-web-sdk": {
       "name": "@uphold/enterprise-payment-widget-web-sdk",
       "version": "0.13.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.17.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.18.0",
         "@uphold/enterprise-widget-sdk-core": "^0.12.0"
       }
+    },
+    "packages/payment-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.18.0.tgz",
+      "integrity": "sha512-kHy5HS38QFoneY20eZSunHmQhN1R8fzHibSsIUYCk1TnPgzjJGH47oYklxwN3HBPVDG1ns118WBLogAp1uDpOQ=="
     },
     "packages/travel-rule-widget-web-sdk": {
       "name": "@uphold/enterprise-travel-rule-widget-web-sdk",
       "version": "0.5.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.17.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.18.0",
         "@uphold/enterprise-widget-sdk-core": "^0.12.0"
       }
     },
-    "packages/widget-messaging-types": {
-      "name": "@uphold/enterprise-widget-messaging-types",
-      "version": "0.0.0",
-      "extraneous": true
-    },
-    "projects/payment-widget": {
-      "name": "@uphold/enterprise-payment-widget",
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "@chakra-ui/react": "^3.13.0",
-        "@emotion/react": "^11.14.0",
-        "@react-router/node": "^7.2.0",
-        "@react-router/serve": "^7.2.0",
-        "i18next": "^24.2.2",
-        "i18next-browser-languagedetector": "^8.0.4",
-        "i18next-http-backend": "^3.0.2",
-        "isbot": "^5.1.17",
-        "prop-types": "^15.8.1",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "react-i18next": "^15.4.1",
-        "react-router": "^7.3.0"
-      },
-      "devDependencies": {
-        "@react-router/dev": "^7.2.0",
-        "react-router-devtools": "^1.1.0",
-        "vite": "^6.2.1",
-        "vite-tsconfig-paths": "^5.1.4"
-      }
-    },
-    "projects/payment-widget-js-sdk": {
-      "name": "@uphold/enterprise-payment-widget-js-sdk",
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "i18next": "^24.2.2",
-        "i18next-browser-languagedetector": "^8.0.4",
-        "i18next-http-backend": "^3.0.2"
-      },
-      "devDependencies": {
-        "vite": "^6.2.1",
-        "vite-tsconfig-paths": "^5.1.4"
-      }
-    },
-    "projects/payment-widget-sdk-app": {
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "@uphold/enterprise-payment-widget-js-sdk": "../../packages/payment-widget-js-sdk"
-      },
-      "devDependencies": {
-        "typescript": "~5.7.2",
-        "vite": "^6.2.0"
-      }
+    "packages/travel-rule-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.18.0.tgz",
+      "integrity": "sha512-kHy5HS38QFoneY20eZSunHmQhN1R8fzHibSsIUYCk1TnPgzjJGH47oYklxwN3HBPVDG1ns118WBLogAp1uDpOQ=="
     },
     "projects/widget-test-app": {
       "name": "@uphold/widget-test-app",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.17.0"
+    "@uphold/enterprise-widget-messaging-types": "^0.18.0"
   },
   "devDependencies": {
     "jsdom": "^27.4.0"

--- a/packages/kyc-widget-web-sdk/package.json
+++ b/packages/kyc-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.17.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.18.0",
     "@uphold/enterprise-widget-sdk-core": "^0.12.0"
   }
 }

--- a/packages/payment-widget-web-sdk/package.json
+++ b/packages/payment-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.17.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.18.0",
     "@uphold/enterprise-widget-sdk-core": "^0.12.0"
   }
 }

--- a/packages/travel-rule-widget-web-sdk/README.md
+++ b/packages/travel-rule-widget-web-sdk/README.md
@@ -60,6 +60,44 @@ widget.on('error', (e: TravelRuleWidgetErrorEvent) => {
 widget.mountIframe(document.getElementById('travel-rule-widget-root'));
 ```
 
+### Theming
+
+You can optionally define a theme to customize the widget's appearance using the `theme` option:
+
+```javascript
+const widget = new TravelRuleWidget(travelRuleSession, {
+  theme: {
+    appearance: 'light',
+    background: {
+      dark: '#111113',
+      light: '#edf2ed'
+    },
+    components: {
+      button: { borderRadius: '999px' },
+      card: { borderRadius: '10px' },
+      input: { borderRadius: '8px' }
+    },
+    fontFamily: 'Helvetica',
+    foreground: {
+      dark: '#FFFFFF',
+      light: '#000000'
+    },
+    primary: {
+      dark: '#16cb3e',
+      light: '#0c2801'
+    },
+    primaryForeground: {
+      dark: '#111111',
+      light: '#FFFFFF'
+    },
+    emphasisForeground: {
+      dark: '#FFFFFF',
+      light: '#000000'
+    }
+  }
+});
+```
+
 ### Debugging
 
 The `debug` option enables additional logging to the console, which can help during development. To enable debugging, set the `debug` option to `true` when initializing the widget:

--- a/packages/travel-rule-widget-web-sdk/package.json
+++ b/packages/travel-rule-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.17.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.18.0",
     "@uphold/enterprise-widget-sdk-core": "^0.12.0"
   }
 }

--- a/packages/travel-rule-widget-web-sdk/src/types/travel-rule-widget.ts
+++ b/packages/travel-rule-widget-web-sdk/src/types/travel-rule-widget.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  TravelRuleWidgetOptions as BaseTravelRuleWidgetOptions,
   TravelRuleWidgetFlow,
   TravelRuleWidgetMessageEvent,
   TravelRuleWidgetSession
@@ -20,7 +21,7 @@ import type {
  */
 
 export type { TravelRuleWidgetFlow, TravelRuleWidgetSession };
-export type TravelRuleWidgetOptions = WidgetOptions;
+export type TravelRuleWidgetOptions = WidgetOptions & BaseTravelRuleWidgetOptions;
 
 export type TravelRuleWidgetReadyEvent = WidgetReadyEvent<TravelRuleWidgetMessageEvent>;
 export type TravelRuleWidgetCompleteEvent<TFlow extends TravelRuleWidgetFlow> = WidgetCompleteEvent<


### PR DESCRIPTION
### Description

* Bump of _enterprise-widget-messaging-types_ to v.`0.18.0`
* Update `TravelRuleWidgetOptions` type.
* Update the `README` for the _travel-rule-widget-web-sdk_ package to add a section related to theming support.

### Related issues

[WL-2259](https://uphold.atlassian.net/browse/WL-2259)

[WL-2259]: https://uphold.atlassian.net/browse/WL-2259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ