### PR TITLE
Add support for widget layout option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3167,6 +3167,11 @@
       "resolved": "packages/travel-rule-widget-web-sdk",
       "link": true
     },
+    "node_modules/@uphold/enterprise-widget-messaging-types": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.20.0.tgz",
+      "integrity": "sha512-I84kqlF54dOwvTBAgnjJpE/74rP5IGx4nViMhiAw3+B25h2kowC0SgKUg8O2oqHkUKG3MJ4wIuz0PEo2DLZ6sQ=="
+    },
     "node_modules/@uphold/enterprise-widget-sdk-core": {
       "resolved": "packages/core",
       "link": true
@@ -11130,55 +11135,35 @@
       "name": "@uphold/enterprise-widget-sdk-core",
       "version": "0.13.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.18.0"
+        "@uphold/enterprise-widget-messaging-types": "^0.20.0"
       },
       "devDependencies": {
         "jsdom": "^27.4.0"
       }
     },
-    "packages/core/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.18.0.tgz",
-      "integrity": "sha512-kHy5HS38QFoneY20eZSunHmQhN1R8fzHibSsIUYCk1TnPgzjJGH47oYklxwN3HBPVDG1ns118WBLogAp1uDpOQ=="
-    },
     "packages/kyc-widget-web-sdk": {
       "name": "@uphold/enterprise-kyc-widget-web-sdk",
       "version": "0.2.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.18.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.20.0",
         "@uphold/enterprise-widget-sdk-core": "^0.13.0"
       }
-    },
-    "packages/kyc-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.18.0.tgz",
-      "integrity": "sha512-kHy5HS38QFoneY20eZSunHmQhN1R8fzHibSsIUYCk1TnPgzjJGH47oYklxwN3HBPVDG1ns118WBLogAp1uDpOQ=="
     },
     "packages/payment-widget-web-sdk": {
       "name": "@uphold/enterprise-payment-widget-web-sdk",
       "version": "0.13.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.18.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.20.0",
         "@uphold/enterprise-widget-sdk-core": "^0.13.0"
       }
-    },
-    "packages/payment-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.18.0.tgz",
-      "integrity": "sha512-kHy5HS38QFoneY20eZSunHmQhN1R8fzHibSsIUYCk1TnPgzjJGH47oYklxwN3HBPVDG1ns118WBLogAp1uDpOQ=="
     },
     "packages/travel-rule-widget-web-sdk": {
       "name": "@uphold/enterprise-travel-rule-widget-web-sdk",
       "version": "0.6.0",
       "dependencies": {
-        "@uphold/enterprise-widget-messaging-types": "^0.18.0",
+        "@uphold/enterprise-widget-messaging-types": "^0.20.0",
         "@uphold/enterprise-widget-sdk-core": "^0.13.0"
       }
-    },
-    "packages/travel-rule-widget-web-sdk/node_modules/@uphold/enterprise-widget-messaging-types": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@uphold/enterprise-widget-messaging-types/-/enterprise-widget-messaging-types-0.18.0.tgz",
-      "integrity": "sha512-kHy5HS38QFoneY20eZSunHmQhN1R8fzHibSsIUYCk1TnPgzjJGH47oYklxwN3HBPVDG1ns118WBLogAp1uDpOQ=="
     },
     "projects/widget-test-app": {
       "name": "@uphold/widget-test-app",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.18.0"
+    "@uphold/enterprise-widget-messaging-types": "^0.20.0"
   },
   "devDependencies": {
     "jsdom": "^27.4.0"

--- a/packages/core/src/types/base.ts
+++ b/packages/core/src/types/base.ts
@@ -10,6 +10,7 @@ import type {
   WidgetError,
   WidgetErrorMessageEventData,
   WidgetErrorMessageType,
+  WidgetLayout,
   WidgetMessageEvent,
   WidgetReadyMessageType,
   WidgetThemeOption
@@ -24,6 +25,7 @@ export type {
   WidgetErrorMessageEventData,
   WidgetCompleteMessageEventData,
   WidgetCancelMessageEventData,
+  WidgetLayout,
   WidgetThemeOption
 };
 
@@ -80,5 +82,6 @@ export type WidgetMountIframeOptions = Record<string, unknown>;
 
 export type WidgetOptions = {
   debug?: boolean;
+  layout?: WidgetLayout;
   theme?: WidgetThemeOption;
 };

--- a/packages/kyc-widget-web-sdk/README.md
+++ b/packages/kyc-widget-web-sdk/README.md
@@ -106,6 +106,17 @@ const widget = new KycWidget(kycSession, {
 });
 ```
 
+### Layout
+
+You can optionally control how the widget is laid out on wider viewports using the `layout` option:
+
+- `'boxed'` (default): on wider viewports (≥768px wide and ≥600px tall — i.e. tablet and up), centers the widget and frames its content as a fixed-size card. On smaller viewports, including landscape phones, it renders full-bleed.
+- `'fluid'`: renders the widget full-bleed with no frame or centering, so your own container (e.g. a modal) acts as the frame.
+
+```javascript
+const widget = new KycWidget(kycSession, { layout: 'fluid' });
+```
+
 ### Debugging
 
 The `debug` option enables additional logging to the console, which can help during development. To enable debugging, set the `debug` option to `true` when initializing the widget:

--- a/packages/kyc-widget-web-sdk/package.json
+++ b/packages/kyc-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.18.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.20.0",
     "@uphold/enterprise-widget-sdk-core": "^0.13.0"
   }
 }

--- a/packages/payment-widget-web-sdk/README.md
+++ b/packages/payment-widget-web-sdk/README.md
@@ -98,6 +98,17 @@ const widget = new PaymentWidget(paymentSession, {
 });
 ```
 
+### Layout
+
+You can optionally control how the widget is laid out on wider viewports using the `layout` option:
+
+- `'boxed'` (default): on wider viewports (≥768px wide and ≥600px tall — i.e. tablet and up), centers the widget and frames its content as a fixed-size card. On smaller viewports, including landscape phones, it renders full-bleed.
+- `'fluid'`: renders the widget full-bleed with no frame or centering, so your own container (e.g. a modal) acts as the frame.
+
+```javascript
+const widget = new PaymentWidget(paymentSession, { layout: 'fluid' });
+```
+
 ### Debugging
 
 The `debug` option enables additional logging to the console, which can help during development. To enable debugging, set the `debug` option to `true` when initializing the widget:

--- a/packages/payment-widget-web-sdk/package.json
+++ b/packages/payment-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.18.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.20.0",
     "@uphold/enterprise-widget-sdk-core": "^0.13.0"
   }
 }

--- a/packages/travel-rule-widget-web-sdk/README.md
+++ b/packages/travel-rule-widget-web-sdk/README.md
@@ -98,6 +98,17 @@ const widget = new TravelRuleWidget(travelRuleSession, {
 });
 ```
 
+### Layout
+
+You can optionally control how the widget is laid out on wider viewports using the `layout` option:
+
+- `'boxed'` (default): on wider viewports (≥768px wide and ≥600px tall — i.e. tablet and up), centers the widget and frames its content as a fixed-size card. On smaller viewports, including landscape phones, it renders full-bleed.
+- `'fluid'`: renders the widget full-bleed with no frame or centering, so your own container (e.g. a modal) acts as the frame.
+
+```javascript
+const widget = new TravelRuleWidget(travelRuleSession, { layout: 'fluid' });
+```
+
 ### Debugging
 
 The `debug` option enables additional logging to the console, which can help during development. To enable debugging, set the `debug` option to `true` when initializing the widget:

--- a/packages/travel-rule-widget-web-sdk/package.json
+++ b/packages/travel-rule-widget-web-sdk/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@uphold/enterprise-widget-messaging-types": "^0.18.0",
+    "@uphold/enterprise-widget-messaging-types": "^0.20.0",
     "@uphold/enterprise-widget-sdk-core": "^0.13.0"
   }
 }


### PR DESCRIPTION
### Description

* Expose the optional `layout` ('boxed' | 'fluid') on `WidgetOptions`, forwarded to the iframe via the init message alongside the existing options.
* Bump `@uphold/enterprise-widget-messaging-types` to `^0.20.0`, which introduces `WidgetLayout`, and document the option in each widget `README`.

### Related issues

[Ticket WL-2019](https://uphold.atlassian.net/browse/WL-2019)

### Dependencies ⚠️ 
[Widget PR#265](https://github.com/uphold/enterprise-widget/pull/265)
